### PR TITLE
Remove darkPath option from Dart

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -58,8 +58,6 @@ export const iconData = {
     {
       name: "Dart",
       path: "https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/skills/dart-colored.svg",
-      darkPath:
-        "https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/skills/dart-colored.svg",
       iTag: "dart",
       link: "https://dart.dev/",
     },


### PR DESCRIPTION
Hello, it's me again! 😄

This was causing incorrect SVG URL generation in dark mode
Expected URL: "...dart-colored.svg"
Was getting: "...dart-colored-dark.svg" but Dart has no dark icon
![image](https://user-images.githubusercontent.com/43219246/168399465-3b73ea19-0b38-449b-a1b6-e08d6a032414.png)
