### PR TITLE
Issue with Hashnode Social website display in Markdown. 

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1207,6 +1207,10 @@ export default function Home() {
                           
                       <a href="${profile[1].linkPrefix}${
                       profile[1].linkSuffix
+                    }${
+                      profile[1].linkSuffixTwo
+                        ? `${profile[1].linkSuffixTwo}`
+                        : ""
                     }" target="_blank" rel="noreferrer"><img src="${
                       profile[1].darkPath
                         ? theme == "dark"


### PR DESCRIPTION
Website link dows not include ${profile[1].linkSuffixTwo} 

Basically the ".hashnode.dev" is not being displayed. 