### PR TITLE
Feature/store state

### DIFF
--- a/components/IconSelector.js
+++ b/components/IconSelector.js
@@ -30,7 +30,7 @@ const IconSelector = ({ handleIconToggle, title, iconType }) => {
                   {icon.name}
                 </p>
               </div>
-              {state.skills[iconType].includes(icon) ? (
+              {state.skills[iconType].some(item => item.name === icon.name) ? (
                 <div className="absolute top-0 left-0 w-4 h-4 p-0 overflow-hidden text-xs bg-white border-0 rounded-lg z-10">
                   <ExtraSmallTick />
                 </div>
@@ -38,7 +38,7 @@ const IconSelector = ({ handleIconToggle, title, iconType }) => {
 
               <i
                 className={`${icon.iTag} w-9 h-9 ${
-                  state.skills[iconType].includes(icon)
+                    state.skills[iconType].some(item => item.name === icon.name)
                     ? "colored"
                     : "text-light-400 dark:text-light-500"
                 }`}

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -1,0 +1,1 @@
+export { default as useReducerWithMiddleware } from './useReducerWithMiddleware';

--- a/hooks/useReducerWithMiddleware.js
+++ b/hooks/useReducerWithMiddleware.js
@@ -1,0 +1,36 @@
+import React, { useReducer, useRef } from 'react';
+
+const useReducerWithMiddleware = (
+    reducer,
+    initialState,
+    beforeMiddlewareFns,
+    afterMiddlewareFns
+) => {
+    const [state, dispatch] = useReducer(reducer, initialState);
+
+    const aRef = useRef();
+
+    const dispatchWithMiddleware = (action) => {
+        beforeMiddlewareFns.forEach((beforeMiddlewareFn) =>
+            beforeMiddlewareFn(action, state)
+        );
+
+        aRef.current = action;
+
+        dispatch(action);
+    };
+
+    React.useEffect(() => {
+        if (!aRef.current) return;
+
+        afterMiddlewareFns.forEach((afterwareMiddlewareFn) =>
+            afterwareMiddlewareFn(aRef.current, state)
+        );
+
+        aRef.current = null;
+    }, [afterMiddlewareFns, state]);
+
+    return [state, dispatchWithMiddleware];
+};
+
+export default useReducerWithMiddleware;

--- a/hooks/useReducerWithMiddleware.js
+++ b/hooks/useReducerWithMiddleware.js
@@ -1,5 +1,7 @@
 import React, { useReducer, useRef } from 'react';
 
+
+
 const useReducerWithMiddleware = (
     reducer,
     initialState,
@@ -23,8 +25,8 @@ const useReducerWithMiddleware = (
     React.useEffect(() => {
         if (!aRef.current) return;
 
-        afterMiddlewareFns.forEach((afterwareMiddlewareFn) =>
-            afterwareMiddlewareFn(aRef.current, state)
+        afterMiddlewareFns.forEach((afterMiddlewareFn) =>
+            afterMiddlewareFn(aRef.current, state)
         );
 
         aRef.current = null;

--- a/middleware/storeStateMiddleware.js
+++ b/middleware/storeStateMiddleware.js
@@ -1,0 +1,5 @@
+import {STORED_STATE_KEY} from "../pages/_app";
+
+export default (action, state) => {
+    localStorage.setItem(STORED_STATE_KEY, JSON.stringify(state));
+};

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -991,12 +991,13 @@ function reducer(state, action) {
         },
       };
     case ACTIONS.REMOVE_SKILL:
+
       return {
         ...state,
         skills: {
           ...state.skills,
           [action.payload.type]: state.skills[action.payload.type].filter(
-            (item) => item !== action.payload.icon
+            (item) => item.name !== action.payload.icon.name
           ),
         },
       };

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,14 +1,19 @@
-import React, { useReducer, createContext, useEffect } from "react";
+import React, { createContext, useEffect } from "react";
 import "../styles/globals.css";
 import Script from "next/script";
 import { useRouter } from "next/router";
 import * as gtag from "../lib/gtag";
 import { ThemeProvider } from "next-themes";
+import { useReducerWithMiddleware } from '../hooks'
 import Layout from "../components/layout";
+import storeStateMiddleware from "../middleware/storeStateMiddleware";
 
 export const StateContext = createContext(null);
 
+export const STORED_STATE_KEY = 'state';
+
 export const ACTIONS = {
+  HYDRATE_STORED_STATE: 'hydrate-stored-state',
   ADD_INTRODUCTION: "add-introduction",
   SELECT_RENDER_MODE: "select-render-mode",
   ADD_SKILL: "add-skill",
@@ -943,6 +948,11 @@ const initialState = {
 // Color Reducer
 function reducer(state, action) {
   switch (action.type) {
+
+    // Hydrate the store
+    case ACTIONS.HYDRATE_STORED_STATE:
+      return action.value;
+
     // Show Sections
     case ACTIONS.SHOW_SECTION:
       return {
@@ -1113,7 +1123,8 @@ function reducer(state, action) {
 }
 
 function MyApp({ Component, pageProps }) {
-  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const [state, dispatch] = useReducerWithMiddleware(reducer, initialState ,[], [storeStateMiddleware])
   const router = useRouter();
   useEffect(() => {
     const handleRouteChange = (url) => {
@@ -1124,6 +1135,18 @@ function MyApp({ Component, pageProps }) {
       router.events.off("routeChangeComplete", handleRouteChange);
     };
   }, [router.events]);
+
+  useEffect(() => {
+    const retrievedStoredState = JSON.parse(localStorage.getItem(STORED_STATE_KEY))
+
+    if (retrievedStoredState) {
+
+      dispatch({
+        type: ACTIONS.HYDRATE_STORED_STATE,
+        value: retrievedStoredState,
+      });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/index.js
+++ b/pages/index.js
@@ -259,17 +259,16 @@ export default function Home() {
   };
 
   const handleIconToggle = (iconCategory, iconObj, i) => {
-    if (state.skills[iconCategory].includes(iconObj)) {
-      const iconToRemove = state.skills[iconCategory].indexOf(iconObj);
-      if (iconToRemove > -1) {
-        dispatch({
-          type: ACTIONS.REMOVE_SKILL,
-          payload: {
-            type: iconCategory,
-            icon: iconObj,
-          },
-        });
-      }
+    const isIconAlreadySelectedIndex = state.skills[iconCategory].findIndex((item) => item.name === iconObj.name)
+
+    if (isIconAlreadySelectedIndex >= 0) {
+      dispatch({
+        type: ACTIONS.REMOVE_SKILL,
+        payload: {
+          type: iconCategory,
+          icon: iconObj,
+        },
+      });
     } else {
       dispatch({
         type: ACTIONS.ADD_SKILL,


### PR DESCRIPTION
This issue resolves #7 

The following has been added

* The state of the application is now saved into localstorage. This means that if the user closes the browser window that on page reload the state will be retrieved and the page will be built as it was before

The following has been changed

* The 'skills' section was figuring out if skill icons were selected based on Javascript's array 'include' function. Due to the application loading out the state from localstorage and also creating a new version of the state on initialisation this meant that the objects would not be equal due to object references. To resolve this, skill icon existence checks now compare against the icon name instead

The following has not been added
* A way for the user to easily clear the application state. A simple button and action should resolve this

@danielcranney I have tested this on my side and I will continue to do so. I would also advise that you also test this feature yourself to make sure that you're happy with everything