### PR TITLE
update: changed "class" to "className"

### DIFF
--- a/components/layouts/LandingLayout.js
+++ b/components/layouts/LandingLayout.js
@@ -115,7 +115,7 @@ export default function LandingLayout({ children }) {
           </Link>
 
           {/* ThemeSwitch */}
-          <div class="ml-1 mr-auto">
+          <div className="ml-1 mr-auto">
             <ThemeSwitch />
           </div>
 


### PR DESCRIPTION
Hello Daniel,

I have fixed and changed "class" to "className" for the `ThemeSwitch` component in `components/layouts/LandingLayout.js`