### PR TITLE
fix broken link of github and twitter in footer

### DIFF
--- a/components/misc/SocialIcons.js
+++ b/components/misc/SocialIcons.js
@@ -1,11 +1,12 @@
-import React from "react";
+import React from 'react';
+import TwitterIcon from './TwitterIcon';
+import GitHubIcon from './GitHubIcon';
 
 export const SocialIcons = () => {
-  return (
-    <div className="flex items-center gap-x-1.5">
-      <i className="devicon-github-original text-2xl text-dark-500 hover:text-dark-700 dark:text-light-400 dark:hover:text-white cursor-pointer transition-all duration-150 ease-in-out"></i>
-
-      <i className="devicon-twitter-original text-xl text-dark-500 hover:text-dark-700 dark:text-light-400 dark:hover:text-white cursor-pointer transition-all duration-150 ease-in-out"></i>
-    </div>
-  );
+	return (
+		<div className='flex items-center gap-x-1.5'>
+			<GitHubIcon />
+			<TwitterIcon />
+		</div>
+	);
 };


### PR DESCRIPTION
Closes #25 

## Changes
This is a solution for issue #25. This fixes the issue where the links for GitHub and Twitter in the footer section were broken. 