### PR TITLE
add aria label to light dark mode button

### DIFF
--- a/components/buttons/ThemeSwitch.js
+++ b/components/buttons/ThemeSwitch.js
@@ -59,6 +59,7 @@ const ThemeSwitch = () => {
         }`}
       ></div>
       <button
+        aria-label="change theme"
         onClick={() => {
           setTheme(currentTheme == "dark" ? "light" : "dark");
         }}


### PR DESCRIPTION
#### Issue: light/dark mode button needs aria-label #28

#### I added an aria label to announce the function of the button, which is to change the theme