### PR TITLE
#44 - Expand Support Me options

### DIFF
--- a/components/sections/Support.js
+++ b/components/sections/Support.js
@@ -10,6 +10,7 @@ const Support = React.forwardRef((props, ref) => {
 
   // Support Ref
   const buymeacoffeeRef = useRef();
+  const kofiRef = useRef();
 
   return (
     <>
@@ -33,6 +34,15 @@ const Support = React.forwardRef((props, ref) => {
             inputPlaceholder={"yourname"}
             formLabelText={"Buy Me a Coffee:"}
             linkPrefix={state.support.buymeacoffee.linkPrefix}
+            action={ACTIONS.ADD_SUPPORT}
+          />
+          <SocialItem
+            ref={kofiRef}
+            section={"support"}
+            account={"kofi"}
+            inputPlaceholder={"yourname"}
+            formLabelText={"Buy Me a Coffee:"}
+            linkPrefix={state.support.kofi.linkPrefix}
             action={ACTIONS.ADD_SUPPORT}
           />
           <section className="flex mt-4">

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -760,6 +760,25 @@ export const colorStore = {
   ],
 };
 
+/** 
+ * Temporary store for dynamically creating
+ * support anchors for first-time and re-visiting users.
+ * */
+export const supportStore = {
+  buymeacoffee: {
+    path: "https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/support/buymeacoffee.svg",
+    previewIMG: "https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png",
+    linkPrefix: "https://www.buymeacoffee.com/",
+    linkSuffix: "",
+  },
+  kofi: {
+    path: "https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/support/kofi.svg",
+    previewIMG: "https://storage.ko-fi.com/cdn/kofi2.png?v=3",
+    linkPrefix: "https://www.ko-fi.com/",
+    linkSuffix: "",
+  }
+}
+
 // Color State
 const initialState = {
   section: "introduction",
@@ -945,13 +964,7 @@ const initialState = {
       showIcons: true,
     },
   },
-  support: {
-    buymeacoffee: {
-      path: "https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/support/buymeacoffee.svg",
-      linkPrefix: "https://www.buymeacoffee.com/",
-      linkSuffix: "",
-    },
-  },
+  support: supportStore,
   sidebarOpen: false,
   popOutMenuOpen: false,
   modal: false,

--- a/pages/create-profile.js
+++ b/pages/create-profile.js
@@ -70,7 +70,8 @@ export default function CreateProfile() {
   const [socialsShowing, setSocialsShowing] = useState(false);
   const [badgesShowing, setBadgesShowing] = useState(false);
   const [copySuccess, setCopySuccess] = useState("Copy");
-  const [withSupport, setWithSupport] = useState(false);
+  const withSupport = Object.values(state.support)
+    .some(value => value.linkSuffix !== "");
 
   // Section Refs
   const introductionRef = useRef(null);
@@ -205,11 +206,13 @@ export default function CreateProfile() {
     setMounted(true);
   }, []);
 
+  /**
   useEffect(() => {
     setWithSupport(
       Object.values(state.support).some(value => value.linkSuffix !== "")
     );
   }, [state]);
+  */
 
   const executeScroll = (ref) => {
     if (!ref.current) return;

--- a/pages/create-profile.js
+++ b/pages/create-profile.js
@@ -849,9 +849,8 @@ export default function CreateProfile() {
           >
             {withSupport && <h3>Support</h3> }
             <ul className="list-none">
-              {Object.entries(renderedMarkdown.support).map(([key, value]) => {
-                if (value.linkSuffix) {
-                  return (
+              {Object.entries(renderedMarkdown.support).map(([key, value]) =>
+                value.linkSuffix ? (
                     <li
                       className="inline-block p-1"
                       key={assembleSupportLink(key)}
@@ -864,9 +863,8 @@ export default function CreateProfile() {
                         />
                       </a>
                     </li>
-                  );
-                }
-              })}
+                ) : null
+              )}
             </ul>
           </div>
         </article>

--- a/pages/create-profile.js
+++ b/pages/create-profile.js
@@ -206,14 +206,6 @@ export default function CreateProfile() {
     setMounted(true);
   }, []);
 
-  /**
-  useEffect(() => {
-    setWithSupport(
-      Object.values(state.support).some(value => value.linkSuffix !== "")
-    );
-  }, [state]);
-  */
-
   const executeScroll = (ref) => {
     if (!ref.current) return;
     ref.current.scrollIntoView({

--- a/pages/create-profile.js
+++ b/pages/create-profile.js
@@ -237,7 +237,7 @@ export default function CreateProfile() {
   };
 
   const getSupportPreviewIMG = (key, value) => {
-    return value?.previewIMG || supportStore[key].previewIMG
+    return value?.previewIMG ?? supportStore[key].previewIMG;
   };
 
   const handleBadgeToggle = (e) => {
@@ -847,10 +847,12 @@ export default function CreateProfile() {
             ref={supportRef}
             className={`flex flex-col gap-x-2 gap-y-2 ${withSupport ? "mt-4" : ""}`}
           >
-            {withSupport && <h3>Support</h3> }
-            <ul className="list-none">
-              {Object.entries(renderedMarkdown.support).map(([key, value]) =>
-                value.linkSuffix ? (
+            {withSupport && (
+              <>
+                <h3>Support</h3>
+                <ul className="list-none">
+                {Object.entries(renderedMarkdown.support).map(([key, value]) =>
+                  value.linkSuffix ? (
                     <li
                       className="inline-block p-1"
                       key={assembleSupportLink(key)}
@@ -863,9 +865,11 @@ export default function CreateProfile() {
                         />
                       </a>
                     </li>
-                ) : null
-              )}
-            </ul>
+                  ) : null
+                )}
+                </ul>
+              </>
+            )}
           </div>
         </article>
 

--- a/public/icons/support/kofi.svg
+++ b/public/icons/support/kofi.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg15"
+   sodipodi:docname="ko-fi-icon.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata21">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Artboard</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs19" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     id="namedview17"
+     showgrid="false"
+     inkscape:zoom="3.8522727"
+     inkscape:cx="44"
+     inkscape:cy="17.5"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg15" />
+  <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
+  <title
+     id="title2">Artboard</title>
+  <desc
+     id="desc4">Created with Sketch.</desc>
+  <g
+     id="g856"
+     transform="matrix(1.9656019,0,0,1.9656019,-2.8167172e-7,-51.10565)">
+    <g
+       transform="translate(0,26)"
+       id="Group-4"
+       style="fill:none;fill-rule:nonzero;stroke:none;stroke-width:1">
+      <circle
+         id="Oval"
+         cx="16.280001"
+         cy="16.280001"
+         r="16.280001"
+         style="fill:#29abe0" />
+      <path
+         d="m 22.257931,8.8 h 1.607617 C 26.966324,8.8 29.48,11.313676 29.48,14.414452 v 0.330015 c 0,3.100776 -2.513676,5.614452 -5.614452,5.614452 h -1.607617 v 1.689795 c 0,1.431128 -1.160158,2.591286 -2.591286,2.591286 H 7.4312857 C 6.0001581,24.64 4.84,23.479842 4.84,22.048714 V 10.095643 C 4.84,9.3800791 5.4200791,8.8 6.1356429,8.8 Z m 0,2.996757 v 5.565405 h 1.465573 c 1.536844,0 2.782703,-1.245858 2.782703,-2.782702 0,-1.536845 -1.245859,-2.782703 -2.782703,-2.782703 z"
+         id="Rectangle-2"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff" />
+    </g>
+    <g
+       id="Group"
+       transform="translate(4.84,34.8)"
+       style="fill:#ff5e5b;fill-rule:nonzero;stroke:none;stroke-width:1">
+      <path
+         d="M 8.36,5.2768458 C 8.7602942,4.1056152 9.7089414,3.52 11.205941,3.52 c 2.2455,0 3.077965,2.7936503 1.900934,4.62 C 12.322188,9.3575665 10.739896,10.897567 8.36,12.76 5.9801039,10.897567 4.3978123,9.3575665 3.613125,8.14 2.4360941,6.3136503 3.2685587,3.52 5.5140587,3.52 7.0110586,3.52 7.9597058,4.1056152 8.36,5.2768458 Z"
+         id="Path-2"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
### Summary:
Created this PR for this issue: #44. Please let me know if you want me to include all of the Support Me options that have been requested.

### Changes:
- Added svg for Ko-fi.
- Added a `supportStore` for dynamic rendering of Support Me in the Preview and Markdown sections. Moving forward, we can now add more support me options by simply updating the `supportStore` and `Support.js`.
- Reduced support me image size to `150px`.

### Demo:

![Demo Preview](https://user-images.githubusercontent.com/89898304/210070121-8ef623d2-ac65-47df-a51e-e606710974ee.png)

![Demo Markdown](https://user-images.githubusercontent.com/89898304/210070126-b37baa20-a734-4fec-9b08-eb48cc06455c.png)
