### PR TITLE
fix: Preserve longDescription paragraphs in Markdown

### DIFF
--- a/pages/create-profile.js
+++ b/pages/create-profile.js
@@ -507,9 +507,11 @@ export default function CreateProfile() {
             ) : null}
 
             {state.introduction.longDescription ? (
-              <p className="whitespace-pre-line">
-                {state.introduction.longDescription}
-              </p>
+              state.introduction.longDescription.split('\n').map((line) => (
+                <p className="whitespace-pre-line">
+                  {line}
+                </p>
+              ))
             ) : null}
 
             <ul


### PR DESCRIPTION
This patch preserves paragraphs entered in the longDescription field by converting each line to `<p>` elements in HTML, which is converted to a paragraph in markdown via the touchdown service.

Only lines with non-whitespace characters are displayed in the preview.

I considered enclosing the longDescription field in `<pre>` tags as a simpler approach but single linebreaks wouldn't appear as paragraphs in markdown which is counter-intutive for a non-markdown user.

Related issue: https://github.com/danielcranney/profileme-dev/issues/177

HTML Preview
![image](https://github.com/user-attachments/assets/1bc6ff08-9907-4d2d-945e-2ba0a056d6c0)

markdown preview:
![image](https://github.com/user-attachments/assets/797e10a0-f193-44b3-bbb1-e90c2c7c905b)

