### PR TITLE
fix: Skill icons not adjusting with system theme

### DIFF
--- a/pages/create-profile.js
+++ b/pages/create-profile.js
@@ -92,8 +92,7 @@ export default function CreateProfile() {
         {category.map((icon) => (
           <>
             <span key={`skill-${icon.name}`}>
-              {`
-                <a href="${icon.link}" target="_blank" rel="noreferrer">
+              {`<a href="${icon.link}" target="_blank" rel="noreferrer">
                   <picture>
                   <source media="(prefers-color-scheme: dark)" srcset="${`${icon.darkPath ? icon.darkPath : icon.path}`}" />
                   <source media="(prefers-color-scheme: light)" srcset="${`${icon.path}`}" />

--- a/pages/create-profile.js
+++ b/pages/create-profile.js
@@ -91,16 +91,16 @@ export default function CreateProfile() {
       <>
         {category.map((icon) => (
           <>
-            <span key={`${icon.path}`}>
-              {icon.darkPath ? (
-                <>{`<a href="${
-                  icon.link
-                }" target="_blank" rel="noreferrer"><img src="${
-                  theme == "dark" ? icon.darkPath : icon.path
-                }" width="36" height="36" alt="${icon.name}" /></a>`}</>
-              ) : (
-                <>{`<a href="${icon.link}" target="_blank" rel="noreferrer"><img src="${icon.path}" width="36" height="36" alt="${icon.name}" /></a>`}</>
-              )}
+            <span key={`skill-${icon.name}`}>
+              {`
+                <a href="${icon.link}" target="_blank" rel="noreferrer">
+                  <picture>
+                  <source media="(prefers-color-scheme: dark)" srcset="${`${icon.darkPath ? icon.darkPath : icon.path}`}" />
+                  <source media="(prefers-color-scheme: light)" srcset="${`${icon.path}`}" />
+                  <img src="${`${icon.path}`}" width="36" height="36" alt="${icon.name}" />
+                  </picture>
+                </a>
+              `}
             </span>
           </>
         ))}


### PR DESCRIPTION
This patch addresses an issue where the skill icons do not change according to the users' system theme preferences in Markdown output. If a skill is missing a separate dark icon, fall back to light icon.

Issue: https://github.com/danielcranney/profileme-dev/issues/171

Markdown preview:
![image](https://github.com/user-attachments/assets/055b0303-f9f6-41bd-aae0-2553749b4231)

Github Light:
![image](https://github.com/user-attachments/assets/236559f1-f5e3-459d-8ef2-a5f8778b47f0)

Github Dark:
![image](https://github.com/user-attachments/assets/239a75a0-21e9-4e8b-80a6-67e7cf99bd55)
