### PR TITLE
fix: Sidebar menu inaccessible for keyboard users

### DIFF
--- a/components/buttons/MenuItem.js
+++ b/components/buttons/MenuItem.js
@@ -28,7 +28,7 @@ const MenuItem = ({ text, section, icon }) => {
         });
       }}
     >
-      <span
+      <button
         className={`flex items-center w-full transition-all duration-150 ease-in-out ${
           state.section === section
             ? "border-brand text-white bg-dark-800/40 dark:bg-dark-500/20 opacity-100"
@@ -37,7 +37,7 @@ const MenuItem = ({ text, section, icon }) => {
       >
         {icon}
         {text}
-      </span>
+      </button>
     </li>
   );
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -97,7 +97,7 @@ Table Of Contents:
   .menu > li {
     @apply flex items-center hover:cursor-pointer overflow-hidden transition-all duration-150 ease-in-out;
   }
-  .menu > li > span {
+  .menu > li > button {
     @apply border-l-4 h-full flex items-center px-6 py-3 transition-all duration-150 ease-in-out font-semibold uppercase tracking-wide text-xs;
   }
 }


### PR DESCRIPTION
This patch addresses issues of accessing sidebar links for keyboard users. The menu items have been transformed into button elements.

It is now possible to use [tab] key to access sidebar menu items.

Issue: https://github.com/danielcranney/profileme-dev/issues/26

![image](https://github.com/user-attachments/assets/3e334246-ffd1-4a6c-a3ee-4833736e552c)
